### PR TITLE
datetime modify: add examples with other formats

### DIFF
--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -100,6 +100,29 @@ echo $date->format('Y-m-d') . "\n";
 ]]>
    </screen>
   </example>
+  <example>
+   <title>All formats of Date and Time are supported</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = new DateTime('2000-12-31');
+
+$date->modify('July 1st, 2008');
+echo $date->format('Y-m-d') . "\n";
+
+$date->modify('Monday next week');
+echo $date->format('Y-m-d') . "\n";
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+2008-07-01
+2008-07-07
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
The current page only shows examples that use the relative formats: https://www.php.net/manual/en/datetime.modify.php

I added examples with other formats so that users can see that not only the relative format is supported.